### PR TITLE
Turn off AI server to prevent locking 

### DIFF
--- a/games/battlecity/src/main/java/com/codenjoy/dojo/battlecity/services/GameRunner.java
+++ b/games/battlecity/src/main/java/com/codenjoy/dojo/battlecity/services/GameRunner.java
@@ -128,7 +128,7 @@ public class GameRunner extends AbstractGameType implements GameType {
 
     @Override
     public boolean newAI(String aiName) {
-        ApofigSolver.start(aiName, WebSocketRunner.Host.REMOTE_LOCAL);
+//        ApofigSolver.start(aiName, WebSocketRunner.Host.LOCAL);
         return true;
     }
 


### PR DESCRIPTION
Turn off AI server to prevent locking  (dependency on tetrisj.jvmhost.net host)